### PR TITLE
Add missing 'awscli' dependencies to 1.24-alpine requirements.txt

### DIFF
--- a/1.24-alpine/requirements.txt
+++ b/1.24-alpine/requirements.txt
@@ -1,5 +1,26 @@
 -r requirements-base.txt
+awscli==1.32.116
+botocore==1.34.116
+certifi==2024.2.2
+charset-normalizer==3.3.2
+colorama==0.4.6
+docutils==0.16
+filelock==3.14.0
+idna==3.7
+jmespath==1.0.1
+looptools==1.2.4
 packaging>=21.3
+pyasn1==0.6.0
 pyparsing==3.0.9
+python-dateutil==2.9.0.post0
+PyYAML==6.0.1
+requests==2.32.3
+requests-file==2.1.0
 retrying==1.3.4
+rsa==4.7.2
+s3transfer==0.10.1
 six>=1.16.0
+tldextract==5.1.2
+tqdm==4.66.4
+urllib3==2.2.1
+validators==0.28.3


### PR DESCRIPTION
- fix 1.24-alpine python dependencies (was missing awscli)