### PR TITLE
urllib3 version constraint for Python 3.9 & below

### DIFF
--- a/1.17-alpine-v1/requirements.txt
+++ b/1.17-alpine-v1/requirements.txt
@@ -20,5 +20,6 @@ s3transfer==0.10.1
 six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
-urllib3==1.26.18
+urllib3==1.26.18; python_version < "3.10"
+urllib3==2.2.1; python_version >= "3.10"
 validators==0.28.3

--- a/1.18-alpine-v1/requirements.txt
+++ b/1.18-alpine-v1/requirements.txt
@@ -20,5 +20,6 @@ s3transfer==0.10.1
 six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
-urllib3==1.26.18
+urllib3==1.26.18; python_version < "3.10"
+urllib3==2.2.1; python_version >= "3.10"
 validators==0.28.3

--- a/1.19-alpine-v1/requirements.txt
+++ b/1.19-alpine-v1/requirements.txt
@@ -37,6 +37,7 @@ six>=1.15.0
 tldextract==5.1.2
 toml==0.10.2
 tqdm==4.66.4
-urllib3==1.26.2
+urllib3==1.26.2; python_version < "3.10"
+urllib3==2.2.1; python_version >= "3.10"
 validators==0.28.3
 webencodings==0.5.1

--- a/1.20-alpine-v1/requirements.txt
+++ b/1.20-alpine-v1/requirements.txt
@@ -35,6 +35,7 @@ six>=1.15.0
 tldextract==5.1.2
 toml==0.10.2
 tqdm==4.66.4
-urllib3==1.26.5
+urllib3==1.26.5; python_version < "3.10"
+urllib3==2.2.1; python_version >= "3.10"
 validators==0.28.3
 webencodings==0.5.1

--- a/1.21-alpine-v1/requirements.txt
+++ b/1.21-alpine-v1/requirements.txt
@@ -36,6 +36,7 @@ tldextract==5.1.2
 toml==0.10.2
 tomli==2.0.1
 tqdm==4.66.4
-urllib3==1.26.18
+urllib3==1.26.18; python_version < "3.10"
+urllib3==2.2.1; python_version >= "3.10"
 validators==0.28.3
 webencodings==0.5.1

--- a/1.21-alpine-v2/requirements.txt
+++ b/1.21-alpine-v2/requirements.txt
@@ -36,6 +36,7 @@ tldextract==5.1.2
 toml==0.10.2
 tomli==2.0.1
 tqdm==4.66.4
-urllib3==1.26.18
+urllib3==1.26.18; python_version < "3.10"
+urllib3==2.2.1; python_version >= "3.10"
 validators==0.28.3
 webencodings==0.5.1


### PR DESCRIPTION
- fix urllib3 requirements for Python 3.9 & below