### PR TITLE
OpenSSL RSA key lengths

### DIFF
--- a/1.17-alpine-v1/sites-scripts/certify.sh
+++ b/1.17-alpine-v1/sites-scripts/certify.sh
@@ -79,7 +79,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.18-alpine-v1/sites-scripts/certify.sh
+++ b/1.18-alpine-v1/sites-scripts/certify.sh
@@ -79,7 +79,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.19-alpine-v1/sites-scripts/certify.sh
+++ b/1.19-alpine-v1/sites-scripts/certify.sh
@@ -79,7 +79,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.20-alpine-v1/sites-scripts/certify.sh
+++ b/1.20-alpine-v1/sites-scripts/certify.sh
@@ -79,7 +79,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.21-alpine-v1/sites-scripts/certify.sh
+++ b/1.21-alpine-v1/sites-scripts/certify.sh
@@ -79,7 +79,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.21-alpine-v2/sites-scripts/certify.sh
+++ b/1.21-alpine-v2/sites-scripts/certify.sh
@@ -86,7 +86,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.22-alpine/sites-scripts/certify.sh
+++ b/1.22-alpine/sites-scripts/certify.sh
@@ -86,7 +86,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.23-alpine/sites-scripts/certify.sh
+++ b/1.23-alpine/sites-scripts/certify.sh
@@ -86,7 +86,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.24-alpine/sites-scripts/certify.sh
+++ b/1.24-alpine/sites-scripts/certify.sh
@@ -86,7 +86,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.25-alpine/sites-scripts/certify.sh
+++ b/1.25-alpine/sites-scripts/certify.sh
@@ -86,7 +86,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.26-alpine/sites-scripts/certify.sh
+++ b/1.26-alpine/sites-scripts/certify.sh
@@ -86,7 +86,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"

--- a/1.27-alpine/sites-scripts/certify.sh
+++ b/1.27-alpine/sites-scripts/certify.sh
@@ -86,7 +86,7 @@ if [[ ! -f ${fullchain} ]] || [[ ! -f ${privkey} ]] || [[ ! -f ${cert} ]] || [[ 
     rm -rfv /etc/letsencrypt/live/${domain_current}/chain.pem
 
     echo "Creating dummy certificate for ${domain_current}..."
-    openssl req -x509 -nodes -newkey rsa:1024 -days 1 \
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
         -keyout "/etc/letsencrypt/live/${domain_current}/privkey.pem" \
         -out "/etc/letsencrypt/live/${domain_current}/fullchain.pem" \
         -subj "/CN=localhost"


### PR DESCRIPTION
- fix rsa key lengths to 2048 in order to solve "SSL routines::ee key too small" bugs in production webservers